### PR TITLE
Update tpunit++.hpp

### DIFF
--- a/tpunit++.hpp
+++ b/tpunit++.hpp
@@ -52,8 +52,8 @@ extern "C" int printf(const char*, ...);
  * TRACE(message); adds a trace to the test output with a user
  * specified string message.
  */
-#define ABORT() __assert(__FILE__, __LINE__); return;
-#define FAIL()  __assert(__FILE__, __LINE__);
+#define ABORT() __tpunitassert(__FILE__, __LINE__); return;
+#define FAIL()  __tpunitassert(__FILE__, __LINE__);
 #define PASS()  /* do nothing */
 #define TRACE(message) __trace(__FILE__, __LINE__, message);
 
@@ -451,7 +451,7 @@ namespace tpunit {
                    ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
          }
 
-         static void __assert(const char* _file, int _line) {
+         static void __tpunitassert(const char* _file, int _line) {
             printf("[              ]    assertion #%i at %s:%i\n", ++__stats()._assertions, _file, _line);
          }
 


### PR DESCRIPTION
the function __assert conflicts with a macro defined in assert.h on OS X 10.10. renaming the function in this file removes the conflict and makes it quite unlikely that this will conflict with anything else in the future.