### PR TITLE
Adds an optional test name

### DIFF
--- a/tpunit++.hpp
+++ b/tpunit++.hpp
@@ -23,6 +23,7 @@
 #define __TPUNITPP_HPP__
 
 #include <cstdio>
+#include <string.h>
 
 /**
  * TPUNITPP_VERSION macro contains an integer represented by
@@ -305,14 +306,16 @@ namespace tpunit {
             return new method(this, static_cast<void (TestFixture::*)()>(_method), _name, _type);
          }
 
-         static int tpunit_detail_do_run() {
+         static int tpunit_detail_do_run(const char* test_name = 0) {
             TestFixture* f = *tpunit_detail_fixtures();
              while(f) {
-                printf("[--------------]\n");
-                tpunit_detail_do_methods(f->_before_classes);
-                tpunit_detail_do_tests(f);
-                tpunit_detail_do_methods(f->_after_classes);
-                printf("[--------------]\n\n");
+                if (test_name == 0 || (f->_name && !strcmp(test_name, f->_name))) {
+                   printf("[--------------]\n");
+                   tpunit_detail_do_methods(f->_before_classes);
+                   tpunit_detail_do_tests(f);
+                   tpunit_detail_do_methods(f->_after_classes);
+                   printf("[--------------]\n\n");
+                }
                 f = f->_next;
              }
              printf("[==============]\n");
@@ -412,6 +415,8 @@ namespace tpunit {
             printf("[              ]    trace #%i at %s:%i: %s\n", ++tpunit_detail_stats()._traces, _file, _line, _message);
          }
 
+         const char* _name = 0;
+
       private:
 
          static void tpunit_detail_do_method(method* m) {
@@ -487,6 +492,16 @@ namespace tpunit {
       static int run() {
          return TestFixture::tpunit_detail_do_run();
       }
+
+      /**
+       * Run only registered test cases whose names match the given string, and return the number of failed assertions.
+       *
+       * @return Number of failed assertions or zero if all tests pass.
+       */
+      static int run(const char* test_name) {
+          return TestFixture::tpunit_detail_do_run(test_name);
+      }
+
    };
 } // namespace tpunit
 #endif //__TPUNITPP_HPP__

--- a/tpunit++main.cpp
+++ b/tpunit++main.cpp
@@ -20,12 +20,33 @@
  * THE SOFTWARE.
  */
 #include "tpunit++.hpp"
+#include <string>
+#include <set>
 
-int main() {
+void parse_options(int argc, char* argv[], std::set<std::string>& include, std::set<std::string>& exclude) {
+   for (int i = 0; i < argc; i++){
+      char* arg = argv[i];
+      char* in = strstr(arg, "--include=");
+      char* ex = strstr(arg, "--exclude=");
+      if (in == arg) {
+         include.insert(arg + 10);
+      }
+      else if (ex == arg) {
+         exclude.insert(arg + 10);
+      }
+   }
+}
+
+int main(int argc, char* argv[]) {
+
+   std::set<std::string> include, exclude;
+   parse_options(argc, argv, include, exclude);
+
    /**
-    * Run all of the registered tpunit++ tests. Returns 0 if
-    * all tests are successful, otherwise returns the number
-    * of failing assertions.
+    * Run all of the registered tpunit++ tests that aren't excluded based on
+    * the command line arguments.
+    * Returns 0 if all tests are successful, otherwise returns the number of
+    * failing assertions.
     */
-   return tpunit::Tests::run();
+   return tpunit::Tests::run(include, exclude);
 }

--- a/tpunit++test.cpp
+++ b/tpunit++test.cpp
@@ -39,7 +39,9 @@ struct TPUnitPPTest : tpunit::TestFixture {
       AFTER(TPUnitPPTest::after),
       AFTER_CLASS(TPUnitPPTest::after_class)
    )
-   {}
+   {
+      NAME(TPUnitPPTest);
+   }
 
    int __after_num,  __after_class_num,
        __before_num, __before_class_num,


### PR DESCRIPTION
This change adds an (optional) name to a `TestFixture`.

This allows you to create a `TestFixture` as such:

```
MyTest() : tpunit::TestFixture(BEFORE_CLASS(MyTest::setup),
                                             TEST(MyTest::testMyThing),
                                             AFTER_CLASS(StripeTest::tearDown)) {
    NAME(MyTest);
}
```

And then later on invoke your test by doing:

```
set<string> include, exclude;
include.insert("MyTest");
tpunit::Tests::run(include, exclude);
```

This makes it easy to conditionally separate groups of tests and allows for, for instance, the following:

```
if (each_build) {
    set<string> include, exclude;
    exclude.insert("SlowTest");
    tpunit::Tests::run(include, exlude);
}
else if (nightly_comprehensive) {
    // Just run everything.
    tpunit::Tests::run();
}
```

Unnamed tests will still be run when `include` is left empty.
